### PR TITLE
Create drag-and-drop exceptions for elements within DndContext

### DIFF
--- a/src/customLibs/DndKitSensors.js
+++ b/src/customLibs/DndKitSensors.js
@@ -1,0 +1,23 @@
+import { MouseSensor as DndKitMouseSensor, TouchSensor as DndKitTouchSensor } from '@dnd-kit/core'
+
+// Block DnD event propagation if element have "data-no-dnd" attribute
+const handler = ({ nativeEvent: event }) => {
+  let cur = event.target
+
+  while (cur) {
+    if (cur.dataset && cur.dataset.noDnd) {
+      return false
+    }
+    cur = cur.parentElement
+  }
+
+  return true
+}
+
+export class MouseSensor extends DndKitMouseSensor {
+  static activators = [{ eventName: 'onMouseDown', handler }]
+}
+
+export class TouchSensor extends DndKitTouchSensor {
+  static activators = [{ eventName: 'onTouchStart', handler }]
+}

--- a/src/pages/Boards/BoardContent/BoardContent.jsx
+++ b/src/pages/Boards/BoardContent/BoardContent.jsx
@@ -5,8 +5,8 @@ import { mapOrder } from '~/utils/sorts'
 import { generatePlaceholderCard } from '~/utils/formatters'
 import {
   DndContext,
-  MouseSensor,
-  TouchSensor,
+  // MouseSensor,
+  // TouchSensor,
   useSensor,
   useSensors,
   DragOverlay,
@@ -15,10 +15,10 @@ import {
   pointerWithin,
   getFirstCollision
 } from '@dnd-kit/core'
+import { MouseSensor, TouchSensor } from '~/customLibs/DndKitSensors'
 
 import { cloneDeep, isEmpty } from 'lodash'
 import { arrayMove } from '@dnd-kit/sortable'
-
 import Column from './ListColumns/Column/Column'
 import Card from './ListColumns/Column/ListCards/Card/Card'
 

--- a/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
@@ -207,6 +207,7 @@ function Column({ column }) {
                 size="small"
                 variant="outlined"
                 autoFocus
+                data-no-dnd="true"
                 value={newCardTitle}
                 onChange={(e) => setNewCardTitle(e.target.value)}
                 sx={{
@@ -235,6 +236,7 @@ function Column({ column }) {
               />
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <Button
+                  data-no-dnd="true"
                   onClick={handleAddNewCard}
                   variant="contained"
                   color="success"


### PR DESCRIPTION
- Fix lỗi bôi đen text trong TextField tạo mới Card bị trigger kéo thả columns.
- Thêm thuộc tính 'data-no-dnd' cho các trường cần ngoại lệ
- Ví dụ:
![image](https://github.com/nqbao47/trello-web/assets/81466050/50c861b6-edd9-4f11-85e4-ad254d2252ba)
